### PR TITLE
fix jsdom to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "fs.extra": "*",
-    "jsdom": "*",
+    "jsdom": "1.5.0",
     "marked": "*",
     "minimist": "*"
   }


### PR DESCRIPTION
prevents a breaking change where jsdom 4.x is incompatible with nodejs, but gets pulled by npm anyway.